### PR TITLE
Add ChatGPT CLI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,19 @@ and pypdf
 ```
 pip install pypdf cryptography>=3.1
 ```
+and the OpenAI client
+```
+pip install openai
+```
 
 ## Usage
-Run the script:
+Run the script to download and parse your bills:
 ```
 python main.py
 ```
 
-The script searches for credit card bill emails from the last month and downloads their attachments, parses the content of the bills, and finally feed into OpenAI API, you can interact it with the input box later showing up.
+After `parsed.txt` is generated you can chat with ChatGPT about the data. Set the `OPENAI_API_KEY` environment variable and run:
+```
+python chat.py
+```
+The assistant will get the bill contents once and then you can ask follow up questions without resending the file each time.

--- a/chat.py
+++ b/chat.py
@@ -1,0 +1,69 @@
+import os
+import openai
+
+PARSED_FILE = "parsed.txt"
+
+
+def load_bill(path=PARSED_FILE) -> str:
+    """Return the content of the parsed credit card bill if available."""
+    if not os.path.exists(path):
+        print(f"Could not find {path}, continuing without initial context.")
+        return ""
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def init_openai() -> None:
+    """Configure the OpenAI client using the environment variable."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("OPENAI_API_KEY environment variable is not set")
+    openai.api_key = api_key
+
+
+def send_initial(bill: str):
+    messages = [
+        {
+            "role": "system",
+            "content": "You are a helpful assistant who can answer questions about the user's credit card bill.",
+        },
+    ]
+
+    if bill:
+        messages.append({"role": "user", "content": f"Here is my credit card bill:\n{bill}"})
+        response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+        reply = response.choices[0].message.content
+        print(reply)
+        messages.append({"role": "assistant", "content": reply})
+
+    return messages
+
+
+def chat_loop(messages):
+    """Simple CLI interaction loop."""
+    while True:
+        try:
+            user_input = input("You: ")
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not user_input:
+            continue
+        if user_input.lower() in {"quit", "exit"}:
+            break
+        messages.append({"role": "user", "content": user_input})
+        response = openai.ChatCompletion.create(model="gpt-3.5-turbo", messages=messages)
+        reply = response.choices[0].message.content
+        print(f"Assistant: {reply}")
+        messages.append({"role": "assistant", "content": reply})
+
+
+def main():
+    init_openai()
+    bill = load_bill()
+    history = send_initial(bill)
+    chat_loop(history)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `chat.py` for interacting with OpenAI ChatGPT
- document installing OpenAI client
- update usage instructions to run the new chat script

## Testing
- `python -m py_compile *.py`
- *Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.*

------
https://chatgpt.com/codex/tasks/task_e_68862a40e3808324b07cddfd1fb1f21e